### PR TITLE
adding separate dev dockerfile that works with nodemon

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
     container_name: pyrrha-simulator
     build:
       context: ../Pyrrha-Sensor-Simulator/action
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     image: pyrrha-simulator
     env_file:
       - ../Pyrrha-Sensor-Simulator/action/.env.docker


### PR DESCRIPTION
Signed-off-by: Upkar Lidder <upkarlidder@li-ce6c2fbd-8431-11e8-b370-7440bb93e96e.ibm.com>

**Describe at a high level the solution you're providing**
Added a docker.dev file that works better with docker-compose using nodemon. See issue #13 

**Is this a patch, a minor version change, or a major version change**
Patch, minor, or major.

**Is this related to an open issue?**
Please provide the link.

**Additional context**
Add any other technical detail or considerations here.
