### PR TITLE
updating the pvc names to match the current nomenclature used by IBM

### DIFF
--- a/k8s/Pyrrha-Database/values-production.yaml
+++ b/k8s/Pyrrha-Database/values-production.yaml
@@ -319,7 +319,7 @@ primary:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: "ibmc-block-silver"
+    storageClass: "ibmc-vpc-block-retain-general-purpose"
     ## Persistent Volume Claim annotations
     ##
     annotations: {}
@@ -597,7 +597,7 @@ secondary:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: "ibmc-block-silver"
+    storageClass: "ibmc-vpc-block-retain-general-purpose"
     ## Persistent Volume Claim annotations
     ##
     annotations: {}


### PR DESCRIPTION
Signed-off-by: Upkar Lidder <ulidder@us.ibm.com>

**Describe at a high level the solution you're providing**
Changed the IBM name for persistence claim used by VPC/IKS


