### PR TITLE
Updating helm chart to deploy all sevices with a single chart

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
     depends_on:
       - pyrrha-mariadb
       - pyrrha-wss
+      - pyrrha-mqttserver
     image: pyrrha-mqttclient
     restart: always
     env_file:
@@ -85,39 +86,64 @@ services:
     restart: always
     ports:
       - "4000:4000"
-  #pyrrha-dashboard:
-  #  container_name: pyrrha-dashboard
-  #  build:
-  #    context: ../Pyrrha-Dashboard/pyrrha-dashboard
-  #    dockerfile: Dockerfile.dev
-  #  depends_on:
-  #    - pyrrha-api-auth
-  #    - pyrrha-api-main
-  #    - pyrrha-mqttclient
-  #    - pyrrha-rulesdecision
-  #  image: pyrrha-dashboard
-  #  restart: always
-  #  ports:
-  #    - "3000:3000"
-  #  environment:
-  #    - REACT_APP_MAIN_PROXY=http://pyrrha-api-main:5000
-  #    - REACT_APP_AUTH_PROXY=http://pyrrha-api-auth:4000
-  #    - REACT_APP_WEBSOCKET_URL=ws://localhost:8080
-  #  volumes:
-  #    - /app/node_modules
-  #    - ../Pyrrha-Dashboard/pyrrha-dashboard:/app
-  #  stdin_open: true
-  #pyrrha-simulator:
-  #  container_name: pyrrha-simulator
-  #  build:
-  #    context: ../Pyrrha-Sensor-Simulator/action
-  #    dockerfile: Dockerfile.dev
-  #  image: pyrrha-simulator
-  #  env_file:
-  #    - ../Pyrrha-Sensor-Simulator/action/.env.docker
-  #  restart: always
-  #  environment:
-  #    - NODE_ENV=development
-  #  volumes:
-  #    - /user-app/node_modules
-  #    - ../Pyrrha-Sensor-Simulator/action:/user-app
+  pyrrha-mqttserver:
+    container_name: pyrrha-mqttserver
+    image: vernemq/vernemq:1.12.3
+    restart: always
+    environment:
+      DOCKER_VERNEMQ_ALLOW_ANONYMOUS: "off"
+      DOCKER_VERNEMQ_ACCEPT_EULA: "yes"
+      DOCKER_VERNEMQ_PLUGINS__VMQ_DIVERSITY: "on"
+      DOCKER_VERNEMQ_PLUGINS__VMQ_PASSWD: "off"
+      DOCKER_VERNEMQ_PLUGINS__VMQ_ACL: "off"
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__AUTH_MYSQL__ENABLED: "on"
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__HOST: "pyrrha-mariadb"
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PORT: 3306
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__USER: "root"
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PASSWORD: "${MDB_PASSWORD}"
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__DATABASE: "pyrrha"
+      DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PASSWORD_HASH_METHOD: "sha256"
+    ports:
+      - "1883:1883"
+      - "8888:8888"
+    expose:
+      - 1883
+  pyrrha-dashboard:
+    container_name: pyrrha-dashboard
+    build:
+      context: ../Pyrrha-Dashboard/pyrrha-dashboard
+      dockerfile: Dockerfile.dev
+    depends_on:
+      - pyrrha-api-auth
+      - pyrrha-api-main
+      - pyrrha-mqttclient
+      - pyrrha-rulesdecision
+      - pyrrha-mqttserver
+    image: pyrrha-dashboard
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_MAIN_PROXY=http://pyrrha-api-main:5000
+      - REACT_APP_AUTH_PROXY=http://pyrrha-api-auth:4000
+      - REACT_APP_WEBSOCKET_URL=ws://localhost:8080
+    volumes:
+      - /app/node_modules
+      - ../Pyrrha-Dashboard/pyrrha-dashboard:/app
+    stdin_open: true
+  pyrrha-simulator:
+    container_name: pyrrha-simulator
+    build:
+      context: ../Pyrrha-Sensor-Simulator/action
+      dockerfile: Dockerfile.dev
+    image: pyrrha-simulator
+    depends_on:
+      - pyrrha-mqttserver
+    env_file:
+      - ../Pyrrha-Sensor-Simulator/action/.env.docker
+    restart: always
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - /user-app/node_modules
+      - ../Pyrrha-Sensor-Simulator/action:/user-app

--- a/k8s/Pyrrha-Dashboard/templates/_helpers.tpl
+++ b/k8s/Pyrrha-Dashboard/templates/_helpers.tpl
@@ -18,6 +18,22 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.dash.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "mqttclient.name" -}}
+{{- default .Chart.Name .Values.mqttclient.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "rulesdecision.name" -}}
+{{- default .Chart.Name .Values.rulesdecision.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ws.name" -}}
+{{- default .Chart.Name .Values.ws.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "mqttserver.name" -}}
+{{- default .Chart.Name .Values.mqttserver.name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -81,6 +97,52 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "mqttclient.labels" -}}
+app: {{ include "mychart.name" . }}-{{ .Values.mqttclient.name }}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "mqttclient.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Values.mqttclient.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "rulesdecision.labels" -}}
+app: {{ include "mychart.name" . }}-{{ .Values.rulesdecision.name }}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "rulesdecision.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Values.rulesdecision.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "ws.labels" -}}
+app: {{ include "mychart.name" . }}-{{ .Values.ws.name }}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "ws.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Values.ws.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "mqttserver.labels" -}}
+app: {{ include "mychart.name" . }}-{{ .Values.mqttserver.name }}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "mqttserver.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Values.mqttserver.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+
 {{/*
 Selector labels
 */}}
@@ -104,4 +166,22 @@ app.kubernetes.io/name:  {{ .Values.auth.name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{- define "mqttclient.selectorLabels" -}}
+app.kubernetes.io/name:  {{ .Values.mqttclient.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
+{{- define "rulesdecision.selectorLabels" -}}
+app.kubernetes.io/name:  {{ .Values.rulesdecision.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "ws.selectorLabels" -}}
+app.kubernetes.io/name:  {{ .Values.ws.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "mqttserver.selectorLabels" -}}
+app.kubernetes.io/name:  {{ .Values.mqttserver.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/k8s/Pyrrha-Dashboard/templates/deployments/mqttclient.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/deployments/mqttclient.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "mqttclient.name" . }}
+  labels:
+    {{- include "mqttclient.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mqttclient.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mqttclient.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mqttclient.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.mqttclient.image.pullSecret }}
+      containers:
+        - name: {{ template "mqttclient.name" . }}
+          image: "{{ .Values.mqttclient.image.repository }}:{{ .Values.mqttclient.image.tag }}"
+          volumeMounts:
+            - name: ca-pemstore
+              mountPath: /etc/ssl/certs/messaging.pem
+              subPath: messaging.pem
+              readOnly: false
+          imagePullPolicy: {{ .Values.mqttclient.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.mqttclient.service.internalPort }}
+          env:
+            - name: IOT_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_HOST
+            - name: IOT_TOPIC
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_TOPIC
+            - name: IOT_PROTOCOL
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_PROTOCOL
+            - name: IOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_USERNAME
+            - name: IOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_PASSWORD
+            - name: IOT_SECURE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_SECURE_PORT
+            - name: IOT_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_PORT
+            - name: IOT_CLIENTID
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_CLIENTID
+            - name: IOT_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_PEM
+            - name: IOT_KEEPALIVE
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: IOT_KEEPALIVE
+            - name: MARIADB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: MARIADB_HOST
+            - name: MARIADB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: MARIADB_USERNAME
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: MARIADB_PASSWORD
+            - name: MARIADB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: MARIADB_PORT
+            - name: MARIADB_DB
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: MARIADB_DB
+            - name: WS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: WS_HOST
+            - name: WS_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-client-secret
+                  key: WS_PORT
+          resources:
+            {{ toYaml .Values.mqttclient.resources | indent 12 }}
+                {{- if .Values.mqttclient.nodeSelector }}
+                  nodeSelector:
+            {{ toYaml .Values.mqttclient.nodeSelector | indent 8 }}
+                {{- end }}
+      volumes:
+        - name: ca-pemstore
+          configMap:
+            name: ca-pemstore

--- a/k8s/Pyrrha-Dashboard/templates/deployments/mqttserver.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/deployments/mqttserver.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "mqttserver.name" . }}
+  labels:
+    {{- include "mqttserver.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mqttserver.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mqttserver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mqttserver.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.mqttserver.image.pullSecret }}
+      containers:
+        - name: {{ template "mqttserver.name" . }}
+          image: "{{ .Values.mqttserver.image.repository }}:{{ .Values.mqttserver.image.tag }}"
+          # volumeMounts:
+          #   - name: ca-pemstore
+          #     mountPath: /etc/ssl/certs/messaging.pem
+          #     subPath: messaging.pem
+          #     readOnly: false
+          imagePullPolicy: {{ .Values.mqttserver.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.mqttserver.service.epmd.port }}
+              name: {{ .Values.mqttserver.service.epmd.name }}
+            - containerPort: {{ .Values.mqttserver.service.vmq.port }}
+              name: {{ .Values.mqttserver.service.vmq.name }}
+            - containerPort: {{ .Values.mqttserver.service.tcpMqtt.port }}
+              name: {{ .Values.mqttserver.service.tcpMqtt.name }}
+            - containerPort: 9100
+            - containerPort: 9101
+            - containerPort: 9102
+            - containerPort: 9103
+            - containerPort: 9104
+            - containerPort: 9105
+            - containerPort: 9106
+            - containerPort: 9107
+            - containerPort: 9108
+            - containerPort: 9109
+          env:
+            - name: DOCKER_VERNEMQ_ACCEPT_EULA
+              value: "yes"
+            - name: DOCKER_VERNEMQ_ALLOW_ANONYMOUS
+              value: "off"
+            - name: DOCKER_VERNEMQ_listener__tcp__allowed_protocol_versions
+              value: "3,4,5"
+            - name: DOCKER_VERNEMQ_allow_register_during_netsplit
+              value: "on"
+            - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
+              value: "1"
+            - name: DOCKER_VERNEMQ_KUBERNETES_APP_LABEL
+              value: "vernemq"
+            - name: DOCKER_VERNEMQ_KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MINIMUM
+              value: "9100"
+            - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MAXIMUM
+              value: "9109"
+            - name: DOCKER_VERNEMQ_KUBERNETES_INSECURE
+              value: "1"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_DIVERSITY
+              value: "on"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_PASSWD
+              value: "off"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_ACL
+              value: "off"
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__AUTH_MYSQL__ENABLED
+              value: "on"
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__HOST
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_HOST
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PORT
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_PORT
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__USER
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_USER
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_PASSWORD
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_DATABASE
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PASSWORD_HASH_METHOD
+              value: "sha256"
+          resources:
+            {{ toYaml .Values.mqttserver.resources | indent 12 }}
+                {{- if .Values.mqttserver.nodeSelector }}
+                  nodeSelector:
+            {{ toYaml .Values.mqttserver.nodeSelector | indent 8 }}
+                {{- end }}
+      # volumes:
+      #   - name: ca-pemstore
+      #     configMap:
+      #       name: ca-pemstore

--- a/k8s/Pyrrha-Dashboard/templates/deployments/rulesdecision.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/deployments/rulesdecision.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "rulesdecision.name" . }}
+  labels:
+    {{- include "rulesdecision.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.rulesdecision.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "rulesdecision.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "rulesdecision.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.rulesdecision.image.pullSecret }}
+      containers:
+        - name: {{ template "rulesdecision.name" . }}
+          image: "{{ .Values.rulesdecision.image.repository }}:{{ .Values.rulesdecision.image.tag }}"
+          imagePullPolicy: {{ .Values.rulesdecision.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.rulesdecision.service.internalPort }}
+          env:
+            - name: MARIADB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: rulesdecision-secret
+                  key: MARIADB_HOST
+            - name: MARIADB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: rulesdecision-secret
+                  key: MARIADB_PORT
+            - name: MARIADB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rulesdecision-secret
+                  key: MARIADB_USERNAME
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rulesdecision-secret
+                  key: MARIADB_PASSWORD
+            - name: MARIADB_DB
+              valueFrom:
+                secretKeyRef:
+                  name: rulesdecision-secret
+                  key: MARIADB_DB
+          resources:
+{{ toYaml .Values.rulesdecision.resources | indent 12 }}
+    {{- if .Values.rulesdecision.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.rulesdecision.nodeSelector | indent 8 }}
+    {{- end }}

--- a/k8s/Pyrrha-Dashboard/templates/deployments/ws.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/deployments/ws.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "ws.name" . }}
+  labels:
+    {{- include "ws.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.ws.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ws.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ws.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.ws.image.pullSecret }}
+      containers:
+        - name: {{ template "ws.name" . }}
+          image: "{{ .Values.ws.image.repository }}:{{ .Values.ws.image.tag }}"
+          imagePullPolicy: {{ .Values.ws.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.ws.service.internalPort }}
+          resources:
+{{ toYaml .Values.ws.resources | indent 12 }}
+    {{- if .Values.ws.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ws.nodeSelector | indent 8 }}
+    {{- end }}

--- a/k8s/Pyrrha-Dashboard/templates/services/mqttclient.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/services/mqttclient.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "mqttclient.name" . }}
+  labels:
+    {{- include "mqttclient.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mqttclient.service.type }}
+  ports:
+  - port: {{ .Values.mqttclient.service.internalPort }}
+    name: {{ .Values.mqttclient.service.name }}
+  selector:
+    {{- include "mqttclient.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-Dashboard/templates/services/mqttserver.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/services/mqttserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "mqttserver.name" . }}
+  labels:
+    {{- include "mqttserver.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mqttserver.service.type }}
+  ports:
+  - port: {{ .Values.mqttserver.service.epmd.port }}
+    name: {{ .Values.mqttserver.service.epmd.name }}
+  - port: {{ .Values.mqttserver.service.vmq.port }}
+    name: {{ .Values.mqttserver.service.vmq.name }}
+  - port: {{ .Values.mqttserver.service.tcpMqtt.port }}
+    name: {{ .Values.mqttserver.service.tcpMqtt.name }}
+  selector:
+    {{- include "mqttserver.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-Dashboard/templates/services/mqttserverlb.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/services/mqttserverlb.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mqttservicelb
+  labels:
+    {{- include "mqttserver.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+  - port: {{ .Values.mqttserver.service.tcpMqtt.port }}
+    targetPort: {{ .Values.mqttserver.service.tcpMqtt.port }}
+    name: {{ .Values.mqttserver.service.tcpMqtt.name }}
+    protocol: TCP
+  selector:
+    {{- include "mqttserver.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-Dashboard/templates/services/rulesdecision.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/services/rulesdecision.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rulesdecision.name" . }}
+  labels:
+    {{- include "rulesdecision.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.rulesdecision.service.type }}
+  ports:
+  - port: {{ .Values.rulesdecision.service.internalPort }}
+    name: {{ .Values.rulesdecision.service.name }}
+  selector:
+    {{- include "rulesdecision.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-Dashboard/templates/services/ws.yaml
+++ b/k8s/Pyrrha-Dashboard/templates/services/ws.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ws.name" . }}
+  labels:
+    {{- include "ws.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.ws.service.type }}
+  ports:
+  - port: {{ .Values.ws.service.internalPort }}
+    name: {{ .Values.ws.service.name }}
+  selector:
+    {{- include "ws.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-Dashboard/values-dev.yaml
+++ b/k8s/Pyrrha-Dashboard/values-dev.yaml
@@ -80,3 +80,82 @@ dash:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
+
+rulesdecision:
+  name: rulesdecision
+  image:
+    repository: de.icr.io/prometeo-dev/rulesdecision
+    tag: latest
+    pullSecret: all-icr-io
+    pullPolicy: IfNotPresent
+    # for local development against Minikube registry
+    #pullPolicy: Never  
+  service:
+    type: ClusterIP
+    internalPort: 8080
+    externalPort: 8080
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+mqttclient:
+  name: mqttclient
+  image:
+    repository: de.icr.io/prometeo-dev/mqttclient
+    tag: latest
+    pullSecret: all-icr-io
+    pullPolicy: IfNotPresent
+    # for local development against Minikube registry
+    #pullPolicy: Never  
+  service:
+    type: ClusterIP
+    internalPort: 8080
+    externalPort: 8080
+  resources: {}
+
+ws:
+  name: ws
+  image:
+    repository: de.icr.io/prometeo-dev/ws
+    tag: latest
+    pullSecret: all-icr-io
+    pullPolicy: IfNotPresent
+    # for local development against Minikube registry
+    #pullPolicy: Never  
+  replicaCount: 1
+  service:
+    # name: ws-service
+    type: ClusterIP
+    internalPort: 8080
+  resources: {}
+
+mqttserver:
+  name: mqttserver
+  image:
+    repository: vernemq/vernemq
+    tag: 1.12.3
+    # pullSecret: all-icr-io
+    pullPolicy: IfNotPresent
+    # for local development against Minikube registry
+    #pullPolicy: Never 
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    epmd:
+      port: 4369
+      name: epmd
+    vmq:
+      port: 44053
+      name: vmq
+    tcpMqtt:
+      port: 1883
+      name: tcp-mqtt
+  resources: {}

--- a/k8s/Pyrrha-MQTT-Server/Chart.yaml
+++ b/k8s/Pyrrha-MQTT-Server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
-name: pyrrha
+name: mqttserver
 version: 1.0.0

--- a/k8s/Pyrrha-MQTT-Server/templates/_helpers.tpl
+++ b/k8s/Pyrrha-MQTT-Server/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mychart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mychart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mychart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mychart.labels" -}}
+app: {{ include "mychart.name" . }}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "mychart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mychart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mychart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mychart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mychart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/Pyrrha-MQTT-Server/templates/deployment.yaml
+++ b/k8s/Pyrrha-MQTT-Server/templates/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "mychart.name" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mychart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mychart.labels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          # volumeMounts:
+          #   - name: ca-pemstore
+          #     mountPath: /etc/ssl/certs/messaging.pem
+          #     subPath: messaging.pem
+          #     readOnly: false
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.epmd.port }}
+              name: {{ .Values.service.epmd.name }}
+            - containerPort: {{ .Values.service.vmq.port }}
+              name: {{ .Values.service.vmq.name }}
+            - containerPort: {{ .Values.service.httpDashboard.port }}
+              name: {{ .Values.service.httpDashboard.name }}
+            - containerPort: {{ .Values.service.tcpMqtt.port }}
+              name: {{ .Values.service.tcpMqtt.name }}
+            - containerPort: 9100
+            - containerPort: 9101
+            - containerPort: 9102
+            - containerPort: 9103
+            - containerPort: 9104
+            - containerPort: 9105
+            - containerPort: 9106
+            - containerPort: 9107
+            - containerPort: 9108
+            - containerPort: 9109
+          env:
+            - name: DOCKER_VERNEMQ_ACCEPT_EULA
+              value: "yes"
+            - name: DOCKER_VERNEMQ_ALLOW_ANONYMOUS
+              value: "off"
+            - name: DOCKER_VERNEMQ_listener__tcp__allowed_protocol_versions
+              value: "3,4,5"
+            - name: DOCKER_VERNEMQ_allow_register_during_netsplit
+              value: "on"
+            - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
+              value: "1"
+            - name: DOCKER_VERNEMQ_KUBERNETES_APP_LABEL
+              value: "vernemq"
+            - name: DOCKER_VERNEMQ_KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MINIMUM
+              value: "9100"
+            - name: DOCKER_VERNEMQ_ERLANG__DISTRIBUTION__PORT_RANGE__MAXIMUM
+              value: "9109"
+            - name: DOCKER_VERNEMQ_KUBERNETES_INSECURE
+              value: "1"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_DIVERSITY
+              value: "on"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_PASSWD
+              value: "off"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_ACL
+              value: "off"
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__AUTH_MYSQL__ENABLED
+              value: "on"
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__HOST
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_HOST
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PORT
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_PORT
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__USER
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_USER
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_PASSWORD
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: mqtt-server-secret
+                  key: MARIADB_DATABASE
+            - name: DOCKER_VERNEMQ_VMQ_DIVERSITY__MYSQL__PASSWORD_HASH_METHOD
+              value: "sha256"
+          resources:
+            {{ toYaml .Values.resources | indent 12 }}
+                {{- if .Values.nodeSelector }}
+                  nodeSelector:
+            {{ toYaml .Values.nodeSelector | indent 8 }}
+                {{- end }}
+      # volumes:
+      #   - name: ca-pemstore
+      #     configMap:
+      #       name: ca-pemstore

--- a/k8s/Pyrrha-MQTT-Server/templates/service.yaml
+++ b/k8s/Pyrrha-MQTT-Server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "mychart.name" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.epmd.port }}
+    name: {{ .Values.service.epmd.name }}
+  - port: {{ .Values.service.vmq.port }}
+    name: {{ .Values.service.vmq.name }}
+  - port: {{ .Values.service.httpDashboard.port }}
+    name: {{ .Values.service.httpDashboard.name }}
+  - port: {{ .Values.service.tcpMqtt.port }}
+    name: {{ .Values.service.tcpMqtt.name }}
+  selector:
+    {{- include "mychart.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-MQTT-Server/templates/serviceext.yaml
+++ b/k8s/Pyrrha-MQTT-Server/templates/serviceext.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mqttserviceexternal
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+  - port: {{ .Values.service.tcpMqtt.port }}
+    targetPort: {{ .Values.service.tcpMqtt.port }}
+    name: {{ .Values.service.tcpMqtt.name }}
+    protocol: TCP
+  selector:
+    {{- include "mychart.selectorLabels" . | nindent 4 }}

--- a/k8s/Pyrrha-MQTT-Server/values-dev.yaml
+++ b/k8s/Pyrrha-MQTT-Server/values-dev.yaml
@@ -1,0 +1,33 @@
+# the image properties get overwritten by the IKS toolchain
+image:
+  repository: vernemq/vernemq
+  tag: 1.12.3
+  # pullSecret: all-icr-io
+  pullPolicy: IfNotPresent
+  # for local development against Minikube registry
+  #pullPolicy: Never  
+service:
+  type: ClusterIP
+  epmd:
+    port: 4369
+    name: epmd
+  vmq:
+    port: 44053
+    name: vmq
+  httpDashboard:
+    port: 8888
+    name: http-dashboard
+  tcpMqtt:
+    port: 1883
+    name: tcp-mqtt
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/k8s/Pyrrha-MQTT-Server/values-prod.yaml
+++ b/k8s/Pyrrha-MQTT-Server/values-prod.yaml
@@ -1,0 +1,33 @@
+# the image properties get overwritten by the IKS toolchain
+image:
+  repository: vernemq/vernemq
+  tag: 1.12.3
+  # pullSecret: all-icr-io
+  pullPolicy: IfNotPresent
+  # for local development against Minikube registry
+  #pullPolicy: Never  
+service:
+  type: ClusterIP
+  epmd:
+    port: 4369
+    name: epmd
+  vmq:
+    port: 44053
+    name: vmq
+  httpDashboard:
+    port: 8888
+    name: http-dashboard
+  tcpMqtt:
+    port: 1883
+    name: tcp-mqtt
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/k8s/norewriteingress.yml
+++ b/k8s/norewriteingress.yml
@@ -11,14 +11,14 @@ spec:
         paths:
           - backend:
               service:
-                name: dashboard-api-main-service
+                name: api-main
                 port:
                   number: 5000
             path: /api-main(/|$)(.*)
             pathType: Prefix
           - backend:
               service:
-                name: dashboard-api-auth-service
+                name: api-auth
                 port:
                   number: 4000
             path: /api-auth(/|$)(.*)

--- a/k8s/rewriteingress.yml
+++ b/k8s/rewriteingress.yml
@@ -26,8 +26,8 @@ spec:
             pathType: Prefix
           - backend:
               service:
-                name: dashboard-api-dash-service
+                name: dash
                 port:
                   number: 80
-            path: /api-dash(/|$)(.*)
+            path: /dash(/|$)(.*)
             pathType: Prefix


### PR DESCRIPTION
Signed-off-by: Charlie Evans <charlie.glenn.evans.jr@gmail.com>

Updated Helm chart to include every service (except MariaDB) so all of Pyrrha can be deployed with one chart.
Updated docker compose with an additional MQTT server service
